### PR TITLE
solve issue of low contrast

### DIFF
--- a/app/src/main/res/layout/spoken_numbers_main_fragment.xml
+++ b/app/src/main/res/layout/spoken_numbers_main_fragment.xml
@@ -47,7 +47,7 @@
                 android:layout_gravity="center"
                 android:padding="10dp"
                 android:layout_marginTop="15dp"
-                android:textColor="@color/colorPrimaryDark"
+                android:textColor="#0050FF"
             android:text="@string/high_score" />
 
             <LinearLayout

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,6 +6,7 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+        <item name="titleTextColor">#3C3C3C</item>
         <item name="android:textColorPrimary">@android:color/white</item>
     </style>
 


### PR DESCRIPTION
1.The original text color of the component is '#FFFFFF', and the contrast between the text color ('#FFFFFF') and the background color ('#00C893') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#3C3C3C') are as follows:
![image](https://user-images.githubusercontent.com/101503193/167426027-18042878-734d-4dee-95b9-e53dbcd14e96.png)

The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.

2.The original text color of the component is '#00A89F', and the contrast between the text color ('#00A89F') and the background color ('#C6F0E5') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#0050FF') are as follows:
![image](https://user-images.githubusercontent.com/101503193/167426619-6b358598-16b9-412e-9e66-966b841a965b.png)

The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.

If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.